### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ after_success: npm run coveralls
 language: node_js
 
 node_js:
-  - "4.0"
   - "4"
   - "5"
 

--- a/package.json
+++ b/package.json
@@ -29,17 +29,17 @@
   },
   "homepage": "https://github.com/ruiquelhas/henning#readme",
   "devDependencies": {
-    "code": "3.x.x",
+    "code": "4.x.x",
     "coveralls": "2.x.x",
-    "hapi": "13.x.x",
-    "lab": "10.x.x",
-    "multi-part": "1.x.x"
+    "hapi": "15.x.x",
+    "lab": "11.x.x",
+    "multi-part": "2.x.x"
   },
   "dependencies": {
     "supervizor": "1.x.x",
     "thurston": "2.x.x"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.5.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -50,8 +50,8 @@ lab.experiment('henning', () => {
         const png = Path.join(Os.tmpdir(), 'foo.png');
         const gif = Path.join(Os.tmpdir(), 'foo.gif');
 
-        Fs.createWriteStream(png).end(new Buffer('89504e47', 'hex'));
-        Fs.createWriteStream(gif).end(new Buffer('47494638', 'hex'));
+        Fs.createWriteStream(png).end(Buffer.from('89504e47', 'hex'));
+        Fs.createWriteStream(gif).end(Buffer.from('47494638', 'hex'));
 
         const form = new Form();
         form.append('file1', Fs.createReadStream(gif));
@@ -75,7 +75,7 @@ lab.experiment('henning', () => {
     lab.test('should return control to the server if all files the payload are allowed', (done) => {
 
         const png = Path.join(Os.tmpdir(), 'foo.png');
-        Fs.createWriteStream(png).end(new Buffer('89504e47', 'hex'));
+        Fs.createWriteStream(png).end(Buffer.from('89504e47', 'hex'));
 
         const form = new Form();
         form.append('file1', Fs.createReadStream(png));

--- a/test/index.js
+++ b/test/index.js
@@ -59,7 +59,7 @@ lab.experiment('henning', () => {
         form.append('file3', Fs.createReadStream(gif));
         form.append('foo', 'bar');
 
-        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.get(), url: '/' }, (response) => {
+        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(400);
             Code.expect(response.headers['content-validation']).to.equal('failure');
@@ -82,7 +82,7 @@ lab.experiment('henning', () => {
         form.append('file2', Fs.createReadStream(png));
         form.append('foo', 'bar');
 
-        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.get(), url: '/' }, (response) => {
+        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
             Code.expect(response.headers['content-validation']).to.equal('success');


### PR DESCRIPTION
Update 3rd-party modules and supported node engine. Switch to the new `Buffer` API available since `v4.5.0`.